### PR TITLE
Add: skip policy exit code

### DIFF
--- a/cmd/aqua/main.go
+++ b/cmd/aqua/main.go
@@ -43,7 +43,7 @@ func main() {
 		},
 		&cli.BoolFlag{
 			Name:    "skip-policy-exit-code",
-			Usage:   "Add this flag if you want skip policies exist code",
+			Usage:   "Add this flag if you want skip policies exit code",
 			EnvVars: []string{"TRIVY_SKIP_POLICY_EXIT_CODE"},
 		},
 		&cli.StringFlag{
@@ -72,7 +72,7 @@ func main() {
 		},
 		&cli.BoolFlag{
 			Name:    "skip-policy-exit-code",
-			Usage:   "Add this flag if you want skip policies exist code",
+			Usage:   "Add this flag if you want skip policies exit code",
 			EnvVars: []string{"TRIVY_SKIP_POLICY_EXIT_CODE"},
 		},
 		&cli.BoolFlag{


### PR DESCRIPTION
There is use case that the user will want run the plugin with policy to send the results remotely but dont change the exit code
For example loop on many repositories using automation around the plugin

Also added fix for skip-result-upload after moving to flag cli package