### PR TITLE
feat(cmd): version output

### DIFF
--- a/cmd/aqua/main.go
+++ b/cmd/aqua/main.go
@@ -29,7 +29,7 @@ var (
 func main() {
 	app := cli.NewApp()
 	app.Name = "aqua"
-	app.Version = "0.0.1"
+	app.Version = "0.27.1"
 	app.ArgsUsage = "target"
 	app.Usage = "A simple and comprehensive vulnerability scanner for containers"
 	app.EnableBashCompletion = true
@@ -110,6 +110,9 @@ func main() {
 			EnvVars: []string{"TRIVY_QUIET"},
 		})
 
+	versionCmd := commands.NewVersionCommand()
+	versionCmd.Usage = "print the version of the trivy import library"
+
 	app.Commands = []*cli.Command{
 		fsCmd,
 		configCmd,
@@ -119,6 +122,7 @@ func main() {
 		commands.NewRepositoryCommand(),
 		commands.NewRootfsCommand(),
 		commands.NewServerCommand(),
+		versionCmd,
 	}
 	if err := app.Run(os.Args); err != nil {
 		log.Logger.Error(err)

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	resultsFile = "results.json"
 	aquaPath    = "/tmp/aqua"
+	resultsFile = aquaPath + "/results.json"
 )
 
 //go:embed trivy-secret.yaml
@@ -98,7 +98,7 @@ func Scan(c *cli.Context, path string) (trivyTypes.Results, error) {
 		return nil, errors.Wrap(err, "failed unmarshaling results file")
 	}
 
-	// Cleanup tmp diff dir
+	// Cleanup aqua tmp dir
 	defer os.RemoveAll(aquaPath)
 
 	return results, nil


### PR DESCRIPTION
Print the version of the plugin Trivy import (not the binary)

fix(scan): after secret was found the pattren exist in results.json file so there is another match after rescan
moved to /tmp/aqua and delete after scan.