### PR TITLE
Revert "Updating plugin to latest tag v0.47.1"

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,31 +1,31 @@
 name: "aqua"
 repository: github.com/aquasecurity/trivy-plugin-aqua
-version: "v0.47.1"
+version: "v0.47.0"
 usage: trivy aqua <srcPath>
 description: A Trivy plugin that sends results to Aqua.
 platforms:
   - selector: # optional
       os: linux
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-aqua/releases/download/v0.47.1/linux_amd64_v0.47.1.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-aqua/releases/download/v0.47.0/linux_amd64_v0.47.0.tar.gz
     bin: ./aqua
   - selector:
       os: linux
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-aqua/releases/download/v0.47.1/linux_arm64_v0.47.1.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-aqua/releases/download/v0.47.0/linux_arm64_v0.47.0.tar.gz
     bin: ./aqua
   - selector:
       os: darwin
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-aqua/releases/download/v0.47.1/darwin_amd64_v0.47.1.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-aqua/releases/download/v0.47.0/darwin_amd64_v0.47.0.tar.gz
     bin: ./aqua
   - selector:
       os: darwin
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-plugin-aqua/releases/download/v0.47.1/darwin_arm64_v0.47.1.tar.gz
+    uri: https://github.com/aquasecurity/trivy-plugin-aqua/releases/download/v0.47.0/darwin_arm64_v0.47.0.tar.gz
     bin: ./aqua
   - selector:
       os: windows
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-aqua/releases/download/v0.47.1/windows_amd64_v0.47.1.zip
+    uri: https://github.com/aquasecurity/trivy-plugin-aqua/releases/download/v0.47.0/windows_amd64_v0.47.0.zip
     bin: aqua.exe


### PR DESCRIPTION
Reverts aquasecurity/trivy-plugin-aqua#137

Release process failed :(