### PR TITLE
Don't fail scan if pipeline detection/ scanning fails

### DIFF
--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aquasecurity/defsec/pkg/scan"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-plugin-aqua/pkg/log"
 	"github.com/aquasecurity/trivy-plugin-aqua/pkg/pipelines"
 	"github.com/aquasecurity/trivy-plugin-aqua/pkg/proto/buildsecurity"
 	"github.com/aquasecurity/trivy/pkg/commands/artifact"
@@ -86,11 +87,14 @@ func Scan(c *cli.Context, path string) (*trivyTypes.Report, []*buildsecurity.Pip
 			var files []types.File
 			repositoryPipelines, files, err = pipelines.GetPipelines(opt.Target)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "failed get pipelines")
+				log.Logger.Errorf("failed to get pipelines: %v", err)
 			}
-			pipelinesScanResults, err = ScanPipelines(ctx, repositoryPipelines, files)
-			if err != nil {
-				return nil, nil, errors.Wrap(err, "failed scan pipelines")
+
+			if len(repositoryPipelines) > 0 {
+				pipelinesScanResults, err = ScanPipelines(ctx, repositoryPipelines, files)
+				if err != nil {
+					log.Logger.Errorf("failed scan pipelines: %s", err)
+				}
 			}
 		}
 


### PR DESCRIPTION
Writing an error log if pipeline detection/ scanning fails instead of failing the scan