### PR TITLE
Valid the artifacts link as part of the PR tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ SHELL=/usr/bin/env bash
 
 .PHONY: test
 test:
+	cat ./plugin.yaml | grep uri: | cut -c 10-200 > plugin_artifacts_urls.txt
+	if wget -i ./plugin_artifacts_urls.txt --server-response --quiet "${url}" 2>&1 | grep -q "404"; then echo 'Artifacts links are broken'; exit 1;else echo 'Artifacts links are valid';fi  
 	go test -v ./...
 
 .PHONY: integration-test

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -24,8 +24,3 @@ platforms:
       arch: arm64
     uri: https://github.com/aquasecurity/trivy-plugin-aqua/releases/download/v0.63.1/darwin_arm64_v0.63.1.tar.gz
     bin: ./aqua
-  - selector:
-      os: windows
-      arch: amd64
-    uri: https://github.com/aquasecurity/trivy-plugin-aqua/releases/download/v0.63.1/windows_amd64_v0.63.1.zip
-    bin: aqua.exe


### PR DESCRIPTION
This change helps to catch changes that break the artifacts links at the PR, before they merge to master