### PR TITLE
Updating plugin links and create PR as part of the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
 
       - name: Update plugin Links
         run: |
-          BRANCH_NAME="plugin-update-${{github.ref_name}}"
           sed  -e "s/PLACEHOLDERVERSION/${{github.ref_name}}/g" .github/plugin_template.yaml > plugin.yaml
 
       - name: Create Pull Request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,19 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update plugin Links
+        run: |
+          BRANCH_NAME="plugin-update-${{github.ref_name}}"
+          sed  -e "s/PLACEHOLDERVERSION/${{github.ref_name}}/g" .github/plugin_template.yaml > plugin.yaml
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          branch: "update-plugin-links-${{github.ref_name}}"
+          title: "Update Plugin Artifacts Links for ${{github.ref_name}}"
+          delete-branch: true
+          base: master
+          add-paths: |
+            plugin.yaml

--- a/scripts/update_plugin.sh
+++ b/scripts/update_plugin.sh
@@ -17,15 +17,3 @@ fi
 
 git tag -a ${TAG} -m ${TAG}
 git push --tag
-
-
-BRANCH_NAME="plugin-update-${TAG}"
-
-sed  -e "s/PLACEHOLDERVERSION/${TAG}/g" .github/plugin_template.yaml > plugin.yaml
-git checkout -b $BRANCH_NAME
-
-git add plugin.yaml
-git commit -m "Updating plugin to latest tag ${TAG}" || true
-git push --set-upstream origin $BRANCH_NAME || true
-
-xdg-open "https://github.com/aquasecurity/trivy-plugin-aqua/compare/${BRANCH_NAME}"


### PR DESCRIPTION
This change, move the plugin links updating part from the developer side into the release pipeline after the artifacts were created.
so the new behavior will be:
- a maintainer runs `make update-plugin` with the desired version (which basically just pushes a new tag)
-  The release pipeline is been triggered
   -  It builds the binaries and creates the release
   -  then, it modifies the plugin.yml with the latest links and creates a new PR