### PR TITLE
Bugfixes - local scan, pipeline misconfiguration ids, git commit errors

### DIFF
--- a/pkg/git/commit.go
+++ b/pkg/git/commit.go
@@ -14,12 +14,12 @@ type Commit struct {
 }
 
 func (gc *Client) GetFirstCommit(path string) (Commit, error) {
-	return gc.executeLogCommand(path, "log", "--format=%H%x1f%ai%x1f%aN", "--diff-filter=A", "--", path)
+	return gc.executeLogCommand(path, "log", "--format=%H%x1f%ai%x1f%aN", "--diff-filter=A", "--", filepath.Base(path))
 }
 
 // Gets the last commit that modified the file
 func (gc *Client) GetLastCommit(path string) (Commit, error) {
-	return gc.executeLogCommand(path, "log", "-n", "1", "--format=%H%x1f%ai%x1f%aN", "--", path)
+	return gc.executeLogCommand(path, "log", "-n", "1", "--format=%H%x1f%ai%x1f%aN", "--", filepath.Base(path))
 }
 
 func (gc *Client) executeLogCommand(path string, args ...string) (Commit, error) {

--- a/pkg/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines.go
@@ -179,13 +179,15 @@ func scanPipelines(ctx context.Context, repositoryPipelines []*buildsecurity.Pip
 }
 
 func ExecutePipelineScanning(rootDir string) ([]*buildsecurity.Pipeline, trivyTypes.Results, error) {
+	target := filepath.Clean(rootDir)
+
 	defer func() {
 		if err := recover(); err != nil {
 			log.Logger.Errorw("panic occurred", "error", err)
 		}
 	}()
 
-	pipelines, files, err := getPipelines(rootDir)
+	pipelines, files, err := getPipelines(target)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines.go
@@ -179,7 +179,7 @@ func scanPipelines(ctx context.Context, repositoryPipelines []*buildsecurity.Pip
 }
 
 func ExecutePipelineScanning(rootDir string) ([]*buildsecurity.Pipeline, trivyTypes.Results, error) {
-	target := filepath.Clean(rootDir)
+	target := filepath.Clean(rootDir) // if rootDir == "", this function will return the current directory
 
 	defer func() {
 		if err := recover(); err != nil {

--- a/pkg/pipelines/rules/policies/checkout_persist_credentials.rego
+++ b/pkg/pipelines/rules/policies/checkout_persist_credentials.rego
@@ -3,7 +3,7 @@ package builtin.pipeline.PERSIST_CREDENTIALS
 import data.lib.pipeline
 
 __rego_metadata__ := {
-	"id": "PERSIST_CREDENTIALS",
+	"id": "PIPELINE-0005",
 	"avd_id": "AVD-PIPELINE-0005",
 	"title": "persist-credentials is true",
 	"severity": "HIGH",

--- a/pkg/pipelines/rules/policies/checkout_with_pr_target.rego
+++ b/pkg/pipelines/rules/policies/checkout_with_pr_target.rego
@@ -3,7 +3,7 @@ package builtin.pipeline.CHECKOUT_WITH_PR_TARGET
 import data.lib.pipeline
 
 __rego_metadata__ := {
-	"id": "CHECKOUT_WITH_PR_TARGET",
+	"id": "PIPELINE-0002",
 	"avd_id": "AVD-PIPELINE-0002",
 	"title": "checkout with pull_request_target",
 	"severity": "HIGH",

--- a/pkg/pipelines/rules/policies/dependency_pinned_version.rego
+++ b/pkg/pipelines/rules/policies/dependency_pinned_version.rego
@@ -3,7 +3,7 @@ package builtin.pipeline.DE_PINNED_VERSION
 import data.lib.pipeline
 
 __rego_metadata__ := {
-	"id": "DEPENDENCY_PINNED_VERSION",
+	"id": "PIPELINE-0008",
 	"avd_id": "AVD-PIPELINE-0008",
 	"title": "Unrestricted dependency version",
 	"severity": "MEDIUM",

--- a/pkg/pipelines/rules/policies/eval_command.rego
+++ b/pkg/pipelines/rules/policies/eval_command.rego
@@ -3,7 +3,7 @@ package builtin.pipeline.EVAL_COMMAND
 import data.lib.pipeline
 
 __rego_metadata__ := {
-	"id": "EVAL_COMMAND",
+	"id": "PIPELINE-0004",
 	"avd_id": "AVD-PIPELINE-0004",
 	"title": "Using eval command",
 	"severity": "LOW",

--- a/pkg/pipelines/rules/policies/extra_index_url.rego
+++ b/pkg/pipelines/rules/policies/extra_index_url.rego
@@ -3,7 +3,7 @@ package builtin.pipeline.EXTRA_INDEX_URL
 import data.lib.pipeline
 
 __rego_metadata__ := {
-	"id": "EXTRA_INDEX_URL",
+	"id": "PIPELINE-0001",
 	"avd_id": "AVD-PIPELINE-0001",
 	"title": " Using extra-index-url",
 	"severity": "MEDIUM",

--- a/pkg/pipelines/rules/policies/http_usage.rego
+++ b/pkg/pipelines/rules/policies/http_usage.rego
@@ -3,7 +3,7 @@ package builtin.pipeline.HTTP_USAGE
 import data.lib.pipeline
 
 __rego_metadata__ := {
-	"id": "HTTP_USAGE",
+	"id": "PIPELINE-0011",
 	"avd_id": "AVD-PIPELINE-0011",
 	"title": "HTTP usage instead of HTTPS",
 	"severity": "MEDIUM",

--- a/pkg/pipelines/rules/policies/insecure_fetching.rego
+++ b/pkg/pipelines/rules/policies/insecure_fetching.rego
@@ -3,7 +3,7 @@ package builtin.pipeline.INSECURE_FETCHING
 import data.lib.pipeline
 
 __rego_metadata__ := {
-	"id": "INSECURE_FETCHING",
+	"id": "PIPELINE-0009",
 	"avd_id": "AVD-PIPELINE-0009",
 	"title": "Insecure fetching",
 	"severity": "MEDIUM",

--- a/pkg/pipelines/rules/policies/pipeline_generate_sbom.rego
+++ b/pkg/pipelines/rules/policies/pipeline_generate_sbom.rego
@@ -57,7 +57,7 @@ deny[result] {
 	input.jobs[i].metadata.build == true
 
 	result := {
-		"msg": sprintf("Consider adding SBOM generation tool in build job '%s'", input.jobs[i].name),
+		"msg": sprintf("Consider adding SBOM generation tool in build job '%s'", [input.jobs[i].name]),
 		"startline": input.jobs[i].file_reference.start_ref.line,
 	}
 }

--- a/pkg/pipelines/rules/policies/pipeline_scanned_for_secrets.rego
+++ b/pkg/pipelines/rules/policies/pipeline_scanned_for_secrets.rego
@@ -3,7 +3,7 @@ package builtin.pipeline.SECRET_SCANNING
 import data.lib.pipeline
 
 __rego_metadata__ := {
-	"id": "SECRET_SCANNING",
+	"id": "PIPELINE-0020",
 	"avd_id": "AVD-PIPELINE-0020",
 	"title": "Ensure scanners are in place to identify and prevent sensitive data in pipeline files",
 	"severity": "HIGH",

--- a/pkg/pipelines/rules/policies/pipeline_scanned_for_vulns.rego
+++ b/pkg/pipelines/rules/policies/pipeline_scanned_for_vulns.rego
@@ -3,7 +3,7 @@ package builtin.pipeline.VULN_SCANNING
 import data.lib.pipeline
 
 __rego_metadata__ := {
-	"id": "VULN_SCANNING",
+	"id": "PIPELINE-0021",
 	"avd_id": "AVD-PIPELINE-0021",
 	"title": "Ensure pipelines are automatically scanned for vulnerabilities",
 	"severity": "HIGH",

--- a/pkg/pipelines/rules/policies/untrusted_input_no_env.rego
+++ b/pkg/pipelines/rules/policies/untrusted_input_no_env.rego
@@ -3,7 +3,7 @@ package builtin.pipeline.UNTRUSTED_INPUT_NO_ENV
 import data.lib.pipeline
 
 __rego_metadata__ := {
-	"id": "UNTRUSTED_INPUT_NO_ENV",
+	"id": "PIPELINE-0006",
 	"avd_id": "AVD-PIPELINE-0006",
 	"title": "Potentially untrusted input - environment variable",
 	"severity": "HIGH",

--- a/pkg/pipelines/rules/policies/untrusted_input_usage.rego
+++ b/pkg/pipelines/rules/policies/untrusted_input_usage.rego
@@ -3,7 +3,7 @@ package builtin.pipeline.UNTRUSTED_INPUT_USAGE
 import data.lib.pipeline
 
 __rego_metadata__ := {
-	"id": "UNTRUSTED_INPUT_USAGE",
+	"id": "PIPELINE-0007",
 	"avd_id": "AVD-PIPELINE-0007",
 	"title": "Potentially untrusted input - input usage",
 	"severity": "LOW",

--- a/pkg/pipelines/rules/policies/variable_logging.rego
+++ b/pkg/pipelines/rules/policies/variable_logging.rego
@@ -3,7 +3,7 @@ package builtin.pipeline.VARIABLES_LOGGING
 import data.lib.pipeline
 
 __rego_metadata__ := {
-	"id": "VARIABLES_LOGGING",
+	"id": "PIPELINE-0003",
 	"avd_id": "AVD-PIPELINE-0003",
 	"title": "Echo of variables",
 	"severity": "LOW",

--- a/test/pipelines_test.go
+++ b/test/pipelines_test.go
@@ -77,15 +77,15 @@ func TestPipelines(t *testing.T) {
 				},
 				pipelineMisconfigurationsIds: map[string][]string{
 					"6f25aa81a90ec44064b5b4cd5efeeaeb": {
-						"DEPENDENCY_PINNED_VERSION",
-						"PERSIST_CREDENTIALS",
-						"UNTRUSTED_INPUT_USAGE",
-						"EVAL_COMMAND",
+						"PIPELINE-0004",
+						"PIPELINE-0005",
+						"PIPELINE-0007",
+						"PIPELINE-0008",
 					},
 					"7dbf677abd33b0e9ac85632e62b9020e": {
-						"VARIABLES_LOGGING",
-						"UNTRUSTED_INPUT_NO_ENV",
-						"UNTRUSTED_INPUT_USAGE",
+						"PIPELINE-0003",
+						"PIPELINE-0006",
+						"PIPELINE-0007",
 					},
 				},
 			},
@@ -121,8 +121,9 @@ func TestPipelines(t *testing.T) {
 				},
 				pipelineMisconfigurationsIds: map[string][]string{
 					"0c8c82fe9e5f3000647429d551cdc171": {
-						"EVAL_COMMAND",
-						"INSECURE_FETCHING",
+						"PIPELINE-0004",
+						"PIPELINE-0009",
+						"PIPELINE-0022",
 					},
 				},
 			},
@@ -147,9 +148,9 @@ func TestPipelines(t *testing.T) {
 				},
 				pipelineMisconfigurationsIds: map[string][]string{
 					"80611fdce4e780cf7b3abe982814b6eb": {
-						"EXTRA_INDEX_URL",
-						"HTTP_USAGE",
-						"INSECURE_FETCHING",
+						"PIPELINE-0001",
+						"PIPELINE-0009",
+						"PIPELINE-0011",
 					},
 				},
 			},
@@ -195,9 +196,9 @@ func TestPipelines(t *testing.T) {
 				},
 				pipelineMisconfigurationsIds: map[string][]string{
 					"80611fdce4e780cf7b3abe982814b6eb": {
-						"EXTRA_INDEX_URL",
-						"HTTP_USAGE",
-						"INSECURE_FETCHING",
+						"PIPELINE-0001",
+						"PIPELINE-0009",
+						"PIPELINE-0011",
 					},
 				},
 			},


### PR DESCRIPTION
This PR consists of the following:
- Supporting scanning without providing a path
- Changing pipeline misconfiguration ids to their AVD counterparts
- Fixed an error when calculating metadata of pipeline files using `git log` command