### PR TITLE
Support a new schema of plugin manifest

### DIFF
--- a/.github/plugin_template.yaml
+++ b/.github/plugin_template.yaml
@@ -1,8 +1,9 @@
 name: "aqua"
 repository: github.com/aquasecurity/trivy-plugin-aqua
 version: "PLACEHOLDERVERSION"
-usage: trivy aqua <srcPath>
-description: A Trivy plugin that sends results to Aqua.
+maintainer: aquasecurity
+summary: Send results to Aqua Security
+description: A plugin for integration with Aqua Security SaaS platform
 platforms:
   - selector: # optional
       os: linux

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,8 +1,9 @@
 name: "aqua"
 repository: github.com/aquasecurity/trivy-plugin-aqua
 version: "v0.169.2"
-usage: trivy aqua <srcPath>
-description: A Trivy plugin that sends results to Aqua.
+maintainer: aquasecurity
+summary: Send results to Aqua Security
+description: A plugin for integration with Aqua Security SaaS platform
 platforms:
   - selector: # optional
       os: linux

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2,6 +2,7 @@ name: "aqua"
 repository: github.com/aquasecurity/trivy-plugin-aqua
 version: "v0.170.0"
 maintainer: aquasecurity
+usage: trivy aqua <srcPath> # deprecated: for backward compatibility
 summary: Send results to Aqua Security
 description: A plugin for integration with Aqua Security SaaS platform
 platforms:


### PR DESCRIPTION
## Description
Trivy [added some changes](https://github.com/aquasecurity/trivy/pull/6674) to a schema of `plugin.yaml` for [the plugin index](https://aquasecurity.github.io/trivy-plugin-index/). The changes are as follows:

- Rename usage to summary for clarity
  - Trivy also recognizes usage for backward compatibility.
- Add maintainer

Example: https://github.com/aquasecurity/trivy-plugin-count/commit/b98cf0645db896053481c4faf8bc2724c6ae39b1