### PR TITLE
fix(SLK-129198): Validate GitHub App migration (PR bot + release publisher)

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Generate aqua-pr-bot App token
         id: pr_bot_token
-        uses: aquasecurity/.github-private/.github/actions/github-app-auth@github-app-migration
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.AQUA_PR_BOT_APP_ID }}
           private-key: ${{ secrets.AQUA_PR_BOT_PRIVATE_KEY }}

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -14,6 +14,15 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: arc-runner-set
     steps:
+      - name: Generate aqua-pr-bot App token
+        id: pr_bot_token
+        uses: aquasecurity/.github-private/.github/actions/github-app-auth@github-app-migration
+        with:
+          app-id: ${{ secrets.AQUA_PR_BOT_APP_ID }}
+          private-key: ${{ secrets.AQUA_PR_BOT_PRIVATE_KEY }}
+          owner: aquasecurity
+          repositories: trivy-plugin-aqua
+
       - name: Checkout target branch
         uses: actions/checkout@v2
         with:
@@ -106,4 +115,4 @@ jobs:
         with:
           tag_name: ${{ env.new_version }}
         env:
-          GITHUB_TOKEN: ${{ secrets.PR_CREATION_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.pr_bot_token.outputs.token }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,3 +20,43 @@ jobs:
           else
             echo 'Artifacts links are valid'
           fi
+
+  validate_aqua_pr_bot_auth:
+    name: validate aqua-pr-bot token
+    runs-on: arc-runner-set
+    steps:
+      - name: Generate aqua-pr-bot App token
+        id: pr_bot_token
+        uses: aquasecurity/.github-private/.github/actions/github-app-auth@github-app-migration
+        with:
+          app-id: ${{ secrets.AQUA_PR_BOT_APP_ID }}
+          private-key: ${{ secrets.AQUA_PR_BOT_PRIVATE_KEY }}
+          owner: aquasecurity
+          repositories: trivy-plugin-aqua
+
+      - name: Validate PR bot API access (read-only)
+        env:
+          GH_TOKEN: ${{ steps.pr_bot_token.outputs.token }}
+        run: |
+          gh api repos/aquasecurity/trivy-plugin-aqua --jq .full_name
+          gh api repos/aquasecurity/trivy-plugin-aqua/pulls --jq 'length' || true
+
+  validate_aqua_release_publisher_auth:
+    name: validate aqua-release-publisher token
+    runs-on: arc-runner-set
+    steps:
+      - name: Generate aqua-release-publisher App token
+        id: release_token
+        uses: aquasecurity/.github-private/.github/actions/github-app-auth@github-app-migration
+        with:
+          app-id: ${{ secrets.AQUA_RELEASE_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.AQUA_RELEASE_PUBLISHER_PRIVATE_KEY }}
+          owner: aquasecurity
+          repositories: trivy-plugin-aqua
+
+      - name: Validate release publisher API access (read-only)
+        env:
+          GH_TOKEN: ${{ steps.release_token.outputs.token }}
+        run: |
+          gh api repos/aquasecurity/trivy-plugin-aqua --jq .full_name
+          gh api repos/aquasecurity/trivy-plugin-aqua/releases --jq 'length' || true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,8 +38,10 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.pr_bot_token.outputs.token }}
         run: |
-          gh api repos/aquasecurity/trivy-plugin-aqua --jq .full_name
-          gh api repos/aquasecurity/trivy-plugin-aqua/pulls --jq 'length' || true
+          curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+            https://api.github.com/repos/aquasecurity/trivy-plugin-aqua | jq -r .full_name
+          curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/aquasecurity/trivy-plugin-aqua/pulls?per_page=1" | jq length
 
   validate_aqua_release_publisher_auth:
     name: validate aqua-release-publisher token
@@ -58,5 +60,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.release_token.outputs.token }}
         run: |
-          gh api repos/aquasecurity/trivy-plugin-aqua --jq .full_name
-          gh api repos/aquasecurity/trivy-plugin-aqua/releases --jq 'length' || true
+          curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+            https://api.github.com/repos/aquasecurity/trivy-plugin-aqua | jq -r .full_name
+          curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/aquasecurity/trivy-plugin-aqua/releases?per_page=1" | jq length

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Generate aqua-pr-bot App token
         id: pr_bot_token
-        uses: aquasecurity/.github-private/.github/actions/github-app-auth@github-app-migration
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.AQUA_PR_BOT_APP_ID }}
           private-key: ${{ secrets.AQUA_PR_BOT_PRIVATE_KEY }}
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Generate aqua-release-publisher App token
         id: release_token
-        uses: aquasecurity/.github-private/.github/actions/github-app-auth@github-app-migration
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.AQUA_RELEASE_PUBLISHER_APP_ID }}
           private-key: ${{ secrets.AQUA_RELEASE_PUBLISHER_PRIVATE_KEY }}

--- a/.github/workflows/tag_update.yaml
+++ b/.github/workflows/tag_update.yaml
@@ -16,9 +16,18 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Generate aqua-pr-bot App token
+        id: pr_bot_token
+        uses: aquasecurity/.github-private/.github/actions/github-app-auth@github-app-migration
+        with:
+          app-id: ${{ secrets.AQUA_PR_BOT_APP_ID }}
+          private-key: ${{ secrets.AQUA_PR_BOT_PRIVATE_KEY }}
+          owner: aquasecurity
+          repositories: trivy-plugin-aqua
+
       - name: Update tag to latest
         uses: richardsimko/update-tag@e173a8ef8f54ab526a91dad6139a25efed62424c # v1.0.11
         with:
           tag_name: ${{ inputs.new_version }}
         env:
-          GITHUB_TOKEN: ${{ secrets.PR_CREATION_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.pr_bot_token.outputs.token }}

--- a/.github/workflows/tag_update.yaml
+++ b/.github/workflows/tag_update.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Generate aqua-pr-bot App token
         id: pr_bot_token
-        uses: aquasecurity/.github-private/.github/actions/github-app-auth@github-app-migration
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.AQUA_PR_BOT_APP_ID }}
           private-key: ${{ secrets.AQUA_PR_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Replace `PR_CREATION_TOKEN` with `aqua-pr-bot` in `tag_update.yaml` and `pr-merged.yml`
- Add read-only validation jobs for `aqua-pr-bot` and `aqua-release-publisher` on PRs
- Uses existing repo-level `AQUA_PR_BOT_*` and `AQUA_RELEASE_PUBLISHER_*` secrets

## Test plan
- [ ] PR workflow passes including validation jobs (no releases or PRs created)
- [ ] `testing PR build` continues to pass

