### PR TITLE
fix(ci): resolve Docker Hub description 401 on release workflow

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -28,12 +28,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.ref }}
       - name: Login to docker.io registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.ARGON_DOCKERHUB_USER }}
           password: ${{ secrets.ARGON_DOCKERHUB_TOKEN }}
       - name: login to Aqua Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.AQUASEC_ACR_REGISTRY_NAME }}
           username: ${{ secrets.AQUASEC_ACR_USERNAME }}
@@ -104,7 +104,7 @@ jobs:
           docker manifest create ${{ secrets.AQUASEC_ACR_REGISTRY_NAME }}/aqua-scanner:latest-limited ${{ secrets.AQUASEC_ACR_REGISTRY_NAME }}/aqua-scanner:latest-amd64-limited ${{ secrets.AQUASEC_ACR_REGISTRY_NAME }}/aqua-scanner:latest-arm64-limited
           docker manifest push ${{ secrets.AQUASEC_ACR_REGISTRY_NAME }}/aqua-scanner:latest-limited
       - name: DockerHub description update
-        uses: peter-evans/dockerhub-description@dc67fad7001ef9e8e3c124cb7a64e16d0a63d864 # 3.4.2
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.ARGON_DOCKERHUB_USER }}
           password: ${{ secrets.ARGON_DOCKERHUB_TOKEN }}

--- a/.github/workflows/retag-latest-version.yml
+++ b/.github/workflows/retag-latest-version.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: arc-runner-set
     steps:
       - name: Login to docker.io registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.ARGON_DOCKERHUB_USER }}
           password: ${{ secrets.ARGON_DOCKERHUB_TOKEN }}
       - name: login to Aqua Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.AQUASEC_ACR_REGISTRY_NAME }}
           username: ${{ secrets.AQUASEC_ACR_USERNAME }}


### PR DESCRIPTION
RCA: update docker images used dockerhub-description v3.4.2, which authenticates via deprecated /v2/users/login. Docker Hub org access tokens are rejected on that endpoint, causing 401 at "Acquiring token".

Fix: bump dockerhub-description to v5.0.0 (/v2/auth/token) and docker/login-action to v4 (Node 24 runtime).